### PR TITLE
Remove commented lines before importing

### DIFF
--- a/helpers/find-all-import-paths.js
+++ b/helpers/find-all-import-paths.js
@@ -3,6 +3,9 @@ const path = require('path');
 const findFile = require("./find-file.js");
 
 function findAllImportPaths(dir, content, cb) {
+	//strip comments from content
+	let commentRegex = new RegExp("\/\/.*", "gi")
+	content = content.replace(commentRegex, '');
 	const subStr = "import ";
 	let allImports = [];
 	let regex = new RegExp(subStr,"gi");

--- a/helpers/find-all-import-paths.js
+++ b/helpers/find-all-import-paths.js
@@ -4,8 +4,8 @@ const findFile = require("./find-file.js");
 
 function findAllImportPaths(dir, content, cb) {
 	//strip comments from content
-	let commentRegex = new RegExp("\/\/.*", "gi")
-	content = content.replace(commentRegex, '');
+	let commentRegex = new RegExp("\/\/.*", "gi");
+	content = content.replace(commentRegex, "");
 	const subStr = "import ";
 	let allImports = [];
 	let regex = new RegExp(subStr,"gi");


### PR DESCRIPTION
This removes commented lines to prevent falsely matching sentences containing the word import.  The Oraclize API is a popular library that would cause errors while importing without this fix.

Thanks