### PR TITLE
Support different line endings

### DIFF
--- a/helpers/enforce-line-ending-style.js
+++ b/helpers/enforce-line-ending-style.js
@@ -1,0 +1,8 @@
+const { EOL } = require('os')
+const newlineRe = /(\r\n|\r|\n)/g
+
+function enforceLineEndingStyle(content) {
+	return content.replaceAll(newlineRe, EOL)
+}
+
+module.exports = enforceLineEndingStyle

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const {
 	deduplicateSolidityExpHeaders,
 	deduplicateLicenses
 } = require('./helpers/deduplicate-lines')
+const enforceLineEndingStyle = require('./helpers/enforce-line-ending-style')
 
 flatten()
 
@@ -35,6 +36,7 @@ async function getSourceFiles(dir, path) {
 async function replaceImports(inputFileContent, dir) {
 	let outputFileContent = await replaceAllImportsRecursively(inputFileContent, dir)
 
+	outputFileContent = enforceLineEndingStyle(outputFileContent)
 	outputFileContent = deduplicateLicenses(outputFileContent)
 	outputFileContent = deduplicateSolidityVersoins(outputFileContent)
 	outputFileContent = deduplicateSolidityExpHeaders(outputFileContent)


### PR DESCRIPTION
This module does not work when flattening contracts with different line ending styles. As the deduplicate lines helper uses the line ending style of the current os. If you execute this on a windows host and use contracts with the windows style line ending the flattening breaks.

This CR fixes this by forcing all contracts to follow the line ending style of the current OS.